### PR TITLE
Fixed some python3(.4) issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,18 +187,14 @@ Create an initial URL:
 
 The URL will look like this; redirect the user there so he may
 authenticate and allow your application access to Exact Online (this is
-OAuth):
-
-.. ::
+OAuth)::
 
     https://start.exactonline.nl/api/oauth2/auth?
       client_id=%7B12345678-abcd-1234-abcd-0123456789ab%7D&
       redirect_uri=https%3A//example.com/oauth/success/&
       response_type=code
 
-After authentication he will get redirected back to:
-
-.. ::
+After authentication he will get redirected back to::
 
     https://example.com/oauth/success/?code=...
 

--- a/exactonline/api/manager.py
+++ b/exactonline/api/manager.py
@@ -60,7 +60,7 @@ class Manager(object):
         # kwargs = {'filter': "EntryDate+gt+datetime'2014-01-01'", 'top': 5}
         args = []
         for key, value in kwargs.items():
-            if isinstance(value, unicode):
+            if not isinstance(value, (str, int)):
                 value = value.encode('utf-8')
             else:
                 value = str(value)

--- a/exactonline/http.py
+++ b/exactonline/http.py
@@ -81,7 +81,8 @@ class Options(object):
     # Do we validate the SSL certificate.
     verify_cert = False
     # What we use to validate the SSL certificate.
-    cacert_file = '/etc/ssl/certs/ca-certificates.crt'
+    # cacert_file = '/etc/ssl/certs/ca-certificates.crt'
+    cacert_file = '/etc/ssl/certs/ca-bundle.crt'
     # Optional headers.
     headers = None
 

--- a/exactonline/http.py
+++ b/exactonline/http.py
@@ -227,6 +227,15 @@ def http_put(url, data=None, opt=opt_default):
 
 
 def _http_request(url, method=None, data=None, opt=None):
+
+    # url is bytes, not string, check and convert
+    if url and not isinstance(url, str):
+        url = url.decode('utf-8')
+
+    # data is string, not bytes, check and convert:
+    if data and not isinstance(data, bytes):
+        data = bytes(data, encoding='utf-8')
+
     # Check protocol.
     proto = url.split(':', 1)[0]
     if proto not in opt.protocols:

--- a/exactonline/http.py
+++ b/exactonline/http.py
@@ -25,9 +25,9 @@ try:
 except ImportError:  # python2
     import urllib2 as request
 try:
-    from urllib.parse import urljoin
+    from urllib.parse import urljoin, quote
 except ImportError:  # python2
-    from urlparse import urljoin
+    from urlparse import urljoin, quote
 
 
 # ; helpers
@@ -38,7 +38,7 @@ def binquote(value):
     does not like it when we encode slashes -- in the redirect_uri -- as
     well (which the latter does).
     """
-    return urllib.quote(value.encode('utf-8'))
+    return quote(value.encode('utf-8'))
 
 urljoin  # touch it, we don't use it
 

--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -32,8 +32,7 @@ class ExactRawApi(object):
                      '&response_type=%(response_type)s' %
                      auth_params)
 
-        url = '?'.join([self.storage.get_auth_url().encode('utf-8'),
-                        auth_data])
+        url = '?'.join([self.storage.get_auth_url(), auth_data])
         return url
 
     def request_token(self, code):

--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -149,6 +149,10 @@ class ExactRawApi(object):
         #  "token_type":"bearer",
         #  "expires_in":"600",
         #  "refresh_token":"__1P!I.."}
+
+        if not isinstance(jsondata, str):
+            jsondata = str(jsondata, encoding='utf-8')
+
         decoded = json.loads(jsondata)
 
         # Validate the values.

--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -109,6 +109,10 @@ class ExactRawApi(object):
                                  (method, resource, response))
             decoded = None
         else:
+
+            if response and not isinstance(response, str):
+                response = str(response, encoding='utf-8')
+
             try:
                 decoded = json.loads(response)
             except ValueError:
@@ -119,7 +123,7 @@ class ExactRawApi(object):
         return decoded
 
     def _rest_query(self, method, url, data):
-        token = self.storage.get_access_token().encode('utf-8')
+        token = self.storage.get_access_token() #.encode('utf-8')
         opt_custom = Options()
         opt_custom.headers = {
             'Accept': 'application/json',
@@ -166,3 +170,4 @@ class ExactRawApi(object):
         self.storage.set_access_expiry(int(time()) + expires_in)
         self.storage.set_access_token(decoded['access_token'])
         self.storage.set_refresh_token(decoded['refresh_token'])
+        

--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -170,4 +170,7 @@ class ExactRawApi(object):
         self.storage.set_access_expiry(int(time()) + expires_in)
         self.storage.set_access_token(decoded['access_token'])
         self.storage.set_refresh_token(decoded['refresh_token'])
-        
+
+        if 'store_tokens' in dir(self.storage):
+            self.storage.store_tokens()
+


### PR DESCRIPTION
Using this library in a python3.4 django environment gave some issues regarding string/bytes and bytes/string conversions. I resolved these issues but possibly broke a few things for use with python2.

Also added the possibility for the ExactOnlineConfig module to have a pluggable "store_tokens" method. This is to support sharing tokens in a multi server setup by using a database for example. 
