### PR TITLE
jsondata is not Unicode under Python 3, decode it

### DIFF
--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -158,6 +158,9 @@ class ExactRawApi(object):
         #  "token_type":"bearer",
         #  "expires_in":"600",
         #  "refresh_token":"__1P!I.."}
+
+        if not isinstance(jsondata, str):
+            jsondata = jsondata.decode('utf-8')
         decoded = json.loads(jsondata)
 
         # Validate the values.


### PR DESCRIPTION
When storing an OAuth secret under Python 3, `jsondata` is not a `str`. This causes an exception when `json.loads` is called.

I'm not sure if this is the best solution, but it seems to work fine on Python 2 and 3 and all tests pass.