### PR TITLE
Add vat/VATCodes API support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -295,6 +295,7 @@ Currently, it looks like this:
     ledgeraccounts = LedgerAccounts.as_property()
     receivables = Receivables.as_property()
     relations = Relations.as_property()
+    vatcodes = VatCodes.as_property()
 
 But you can call resources which don't have a helper directly. The
 following two three are equivalent:

--- a/exactonline/api/__init__.py
+++ b/exactonline/api/__init__.py
@@ -18,6 +18,7 @@ from .invoices import Invoices
 from .ledgeraccounts import LedgerAccounts
 from .receivables import Receivables
 from .relations import Relations
+from .vatcodes import VatCodes
 
 
 class ExactApi(
@@ -37,3 +38,4 @@ class ExactApi(
     ledgeraccounts = LedgerAccounts.as_property()
     receivables = Receivables.as_property()
     relations = Relations.as_property()
+    vatcodes = VatCodes.as_property()

--- a/exactonline/api/vatcodes.py
+++ b/exactonline/api/vatcodes.py
@@ -1,0 +1,31 @@
+# vim: set ts=8 sw=4 sts=4 et ai tw=79:
+"""
+Helper for vat code resources.
+
+This file is part of the Exact Online REST API Library in Python
+(EORALP), licensed under the LGPLv3+.
+Copyright (C) 2015 Walter Doekes, OSSO B.V.
+"""
+from .manager import Manager
+
+
+class VatCodes(Manager):
+    resource = 'vat/VATCodes'
+
+    def filter(self, vat_code=None, **kwargs):
+        # $select=ID,Code,Percentage
+        if 'select' not in kwargs:
+            kwargs['select'] = 'ID,Code,Percentage'
+
+        if vat_code is not None:
+            remote_id = self._remote_vat_code(vat_code)
+            self._filter_append(kwargs, u'Code eq %s' % (remote_id,))
+        return super(VatCodes, self).filter(**kwargs)
+
+    def get_percentage(self, vat_code=None, **kwargs):
+        vat = super(VatCodes, self).get(
+            vat_code=vat_code, select='Percentage', **kwargs)
+        return vat['Percentage']
+
+    def _remote_vat_code(self, code):
+        return u"'%s'" % (code.replace("'", "''"),)


### PR DESCRIPTION
This pull request adds support for vat codes to the api. By default it only queries `ID`, `Code` and `Percentage`. It also provides a shortcut for querying the percentage of a certain vat code. For example:

```python
>>> api.vatcodes.percentage(vat_code='2')
0.21
```