### PR TITLE
Added bulk api support and beta calls support

### DIFF
--- a/exactonline/api/v1division.py
+++ b/exactonline/api/v1division.py
@@ -27,9 +27,9 @@ class V1Division(object):
 
         urlbase = 'v1/%d/' % (division,)
 
-        if beta == True:
+        if beta is True:
             urlbase = 'v1/beta/%d/' % (division,)
-        if bulk == True:
+        if bulk is True:
             urlbase = 'v1/%d/bulk/' % (division,)
 
         request = request.update(resource=urljoin(urlbase, request.resource))

--- a/exactonline/api/v1division.py
+++ b/exactonline/api/v1division.py
@@ -17,7 +17,7 @@ class V1DivisionError(ExactOnlineError):
 
 
 class V1Division(object):
-    def restv1(self, request):
+    def restv1(self, request, beta=False, bulk=False):
         try:
             division = self.storage.get_division()
         except MissingSetting:
@@ -26,6 +26,12 @@ class V1Division(object):
             raise V1DivisionError('Division unset/blank in config')
 
         urlbase = 'v1/%d/' % (division,)
+
+        if beta == True:
+            urlbase = 'v1/beta/%d/' % (division,)
+        if bulk == True:
+            urlbase = 'v1/%d/bulk/' % (division,)
+
         request = request.update(resource=urljoin(urlbase, request.resource))
         return self.rest(request)
 


### PR DESCRIPTION
- Added support for bulk API calls
- Added support for beta API calls


Example usage:
**beta** - `api.restv1(GET('financial/GLAccountClassificationMappings'), beta=True)`
**bulk** - `api.restv1(GET('Financial/TransactionLines'), bulk=True)`

If you are routinely pulling all of the transactions, the bulk option greatly increases the speed of it since it fetches 1k per call.