### PR TITLE
Fix AttributeError on sys.stderr.fileno

### DIFF
--- a/exactonline/rawapi.py
+++ b/exactonline/rawapi.py
@@ -66,7 +66,7 @@ class RateLimiter(object):
         """
         assert seconds > 0, seconds
 
-        if sys.stderr and os.isatty(sys.stderr.fileno()):
+        if sys.stderr and sys.stderr.isatty():
             sys.stderr.write(
                 '(sleeping for {} seconds because of ratelimits {!r})\n'
                 .format(seconds, self))


### PR DESCRIPTION
Using the latest version of exact online API in nginx environment causes errors:


```
Error exporting relations
Traceback (most recent call last):
  File "/var/app/current/app/tasks.py", line 162, in exactonline_export_relations_task
    export_one_relation(api, relations_by_code, relations_by_name, item['organisation'], location['location'])
  File "/var/app/current/app/tasks.py", line 138, in export_one_relation
    api.relations.update(existing_relation['ID'], relation_data)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/api/manager.py", line 104, in update
    ret = self._api.restv1(PUT(str(uri), element_dict))
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/api/v1division.py", line 30, in restv1
    return self.rest(request)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/api/unwrap.py", line 25, in rest
    decoded = super(Unwrap, self).rest(request)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/api/autorefresh.py", line 51, in rest
    decoded = super(Autorefresh, self).rest(request)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/rawapi.py", line 229, in rest
    response = self._rest_query(new_request)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/rawapi.py", line 250, in _rest_query
    self.limiter.backoff()
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/rawapi.py", line 59, in backoff
    self.wait(seconds)
  File "/var/app/venv/staging-LQM1lest/lib/python3.8/site-packages/exactonline/rawapi.py", line 69, in wait
    if sys.stderr and os.isatty(sys.stderr.fileno()):
AttributeError: 'LoggingProxy' object has no attribute 'fileno'
```